### PR TITLE
Update sbt and scala

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -14,7 +14,7 @@ licenses += (
 
 homepage := Some(url("http://scala-debugger.org"))
 
-scalaVersion := "2.12.4"
+scalaVersion := "2.12.20"
 
 scalacOptions ++= Seq(
   "-encoding", "UTF-8", "-target:jvm-1.8",

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.0.3
+sbt.version=1.10.3


### PR DESCRIPTION
I updated sbt (and scala) so that this plugin can be published using valid maven coordinates (see sbt https://github.com/sbt/sbt/issues/3410).

Merging this PR and releasing a new version of the plugin will allow me to use BSP support in [Metals](https://github.com/scalameta/metals) which depends on this plugin.

cc @tgodzik